### PR TITLE
Remove branch condition in azure pipeline yaml

### DIFF
--- a/analysis/tests/test_dummy.py
+++ b/analysis/tests/test_dummy.py
@@ -1,0 +1,8 @@
+import pytest
+import analysis
+from analysis.tests.basetest import BaseTest
+
+class TestDummy(BaseTest):
+    def test_dummy(self):
+        assert 10 == 10.0
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ stages:
   - template: ./devtools/azure-pipelines-macos.yml
 
 - stage: Coverage
-  condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
+  condition: succeeded()
   jobs:
     - job:
       pool:


### PR DESCRIPTION
The `Coverage` stage would only run for master branch, so codecov would not be posted too PRs. Removing the master branch condition, we should get codecov reports on PRs.