### PR TITLE
Add test for the entrypoints for CG and atomistic systems.

### DIFF
--- a/tests/conf_test.py
+++ b/tests/conf_test.py
@@ -4,6 +4,7 @@ import pytest
 class ConfTest:
     def get_fn(self, filename):
         import os.path
-
-        full_path = os.path.join(__file__, "include", filename)
+        full_path = os.path.join(
+                os.path.dirname(__file__),
+                "include", filename)
         return full_path

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -8,7 +8,7 @@ class TestEntrypoints(ConfTest):
     def test_entrypoint_atomistic(self):
         traj = self.get_fn("test_aa.dcd")
         top = self.get_fn("test_aa.gro")
-        output_dir = self.get_fn("data")
+        output_dir = self.get_fn(".")
 
         exit_status = os.system(
                 f"analyze -c {top} -f {traj} -o {output_dir} --reload"
@@ -19,7 +19,7 @@ class TestEntrypoints(ConfTest):
     def test_entrypoint_cg(self):
         traj = self.get_fn("test_cg.dcd")
         top = self.get_fn("test_cg.hoomdxml")
-        output_dir = self.get_fn("data")
+        output_dir = self.get_fn(".")
 
         exit_status = os.system(
                 f"analyze -c {top} -f {traj} -o {output_dir} --reload --cg "

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,29 @@
+import pytest
+import numpy as np
+import analysis
+from .conf_test import ConfTest
+import os
+
+class TestEntrypoints(ConfTest):
+    def test_entrypoint_atomistic(self):
+        traj = self.get_fn("test_aa.dcd")
+        top = self.get_fn("test_aa.gro")
+        output_dir = self.get_fn("data")
+
+        exit_status = os.system(
+                f"analyze -c {top} -f {traj} -o {output_dir} --reload"
+                f"> {output_dir+'/log'}")
+
+        assert exit_status == 0
+
+    def test_entrypoint_cg(self):
+        traj = self.get_fn("test_cg.dcd")
+        top = self.get_fn("test_cg.hoomdxml")
+        output_dir = self.get_fn("data")
+
+        exit_status = os.system(
+                f"analyze -c {top} -f {traj} -o {output_dir} --reload --cg "
+                f"> {output_dir+'/log'}")
+
+        assert exit_status == 0
+


### PR DESCRIPTION
This tests the `analyze` command line function for an atomistic and a CG input. This is a temporary addition since we don't have very comprehensive unit tests.